### PR TITLE
Do not apply sanitization to periods in sanitizeRune

### DIFF
--- a/graphite.go
+++ b/graphite.go
@@ -274,9 +274,9 @@ func sanitize(s string) string {
 	return s
 }
 
-// sanitizeRune converts anything that is not a letter or digit to an underscore
+// sanitizeRune converts anything that is not a letter, digit, or period to an underscore
 func sanitizeRune(r rune) rune {
-	if unicode.IsLetter(r) || unicode.IsDigit(r) {
+	if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '.' {
 		return r
 	}
 	// Everything else turns into an underscore


### PR DESCRIPTION
According to Graphite documentation on naming hierarchy, periods
should be allowed in a metric name for creating path components.

https://graphite.readthedocs.io/en/latest/feeding-carbon.html#step-1-plan-a-naming-hierarchy