### PR TITLE
issue 16: mistype causing segfault

### DIFF
--- a/graphite.go
+++ b/graphite.go
@@ -230,7 +230,7 @@ func (e *Exporter) sendBundle(vds []*view.Data) {
 				debugOut("send", metric)
 				err = g.SendMetric(metric)
 				if err != nil {
-					e.opts.OnError(err)
+					e.opts.onError(err)
 				}
 			}
 		}


### PR DESCRIPTION
this is fix for https://github.com/census-ecosystem/opencensus-go-exporter-graphite/issues/16