### PR TITLE
Allow dot dashes in names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.10.x
+  - 1.15.x
 
 go_import_path: contrib.go.opencensus.io/exporter/graphite
 


### PR DESCRIPTION
this is a slight variation of #15 :
```
According to Graphite documentation on naming hierarchy, periods
should be allowed in a metric name for creating path components.

https://graphite.readthedocs.io/en/latest/feeding-carbon.html#step-1-plan-a-naming-hierarchy
```

main difference - change is behavior is controlled by `Options.AllowDotsDashesInNames`.
if/when above flag is not set - existing behavior is preserved